### PR TITLE
Quiz Reward Update

### DIFF
--- a/src/components/pages/Quiz/Quiz.jsx
+++ b/src/components/pages/Quiz/Quiz.jsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { NavLink } from "react-router-dom";
 import RightSideBar from "../../RightSideBar/RightSideBar";
 import { quizData } from "../../../utils/quizData/quizData";
+import { CurrentUserContext } from "../../../contexts/UserContext";
+import { calculateLevel } from "../../../utils/gameLogic/levelSystem";
 import "./Quiz.css";
 
 function Quiz({ achievements }) {
@@ -13,6 +15,7 @@ function Quiz({ achievements }) {
   let [attempt, setAttempt] = useState(1);
   const [locked, setLocked] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const { user, setUser } = useContext(CurrentUserContext);
 
   const handleSubmit = () => {
     if (selectedOption === null) return;
@@ -55,6 +58,25 @@ function Quiz({ achievements }) {
   };
 
   const claimReward = () => {
+    const rewardGems = Number(checkResult()) || 0;
+
+    if (rewardGems <= 0) {
+      setLocked(true);
+      return;
+    }
+
+    setUser((prev) => {
+      if (!prev) return prev;
+      const nextXp = (prev.xp ?? 0) + rewardGems;
+      const nextLevel = calculateLevel(nextXp);
+      return {
+        ...prev,
+        gems: (prev.gems ?? 0) + rewardGems,
+        xp: nextXp,
+        level: nextLevel,
+      };
+    });
+
     setLocked(true);
   };
 

--- a/src/utils/mockData/mockUsers.js
+++ b/src/utils/mockData/mockUsers.js
@@ -28,7 +28,7 @@ export const users = [
     username: "Jordan",
     email: "jordan@test.com",
     password: "1234",
-    level: 21,
+    level: 1,
     xp: 50,
     gems: 100,
     streak: 1,


### PR DESCRIPTION
This pull request enhances the quiz reward system by updating the user's gems, experience points (XP), and level when a reward is claimed, and ensures the user context reflects these changes. It also introduces the `calculateLevel` utility to determine user level based on XP, and makes a minor adjustment to the mock user data for consistency.

**Quiz reward and user context updates:**

* Updated the `claimReward` function in `Quiz.jsx` to increase the user's gems and XP, and recalculate their level using the `calculateLevel` utility when a reward is claimed. The user context (`CurrentUserContext`) is now updated accordingly. [[1]](diffhunk://#diff-315b2b8e77cafdeea6ce005530973608f5aaff0ebb279ec6123ef6cf6553068fL1-R6) [[2]](diffhunk://#diff-315b2b8e77cafdeea6ce005530973608f5aaff0ebb279ec6123ef6cf6553068fR18) [[3]](diffhunk://#diff-315b2b8e77cafdeea6ce005530973608f5aaff0ebb279ec6123ef6cf6553068fR61-R79)
* Imported `calculateLevel` and `CurrentUserContext` into `Quiz.jsx` to support the new reward logic and user updates.

**Mock data adjustment:**

* Changed the initial `level` of the mock user "Jordan" from 21 to 1 in `mockUsers.js` for consistency with their XP.